### PR TITLE
Fix custom view crash on API 21 device

### DIFF
--- a/app/src/main/java/com/flamyoad/honnoki/utils/ui/ToggleView.kt
+++ b/app/src/main/java/com/flamyoad/honnoki/utils/ui/ToggleView.kt
@@ -90,15 +90,13 @@ class ToggleView @JvmOverloads constructor(
     }
 
     override fun onSaveInstanceState(): Parcelable? {
-        val superState = super.onSaveInstanceState()
-        return when (superState) {
+        return when (val superState = super.onSaveInstanceState()) {
             null -> superState
             else -> ToggleSaveState(superState, this.toggleState)
         }
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        super.onRestoreInstanceState(state)
         when (state) {
             is ToggleSaveState -> {
                 super.onRestoreInstanceState(state.superState)


### PR DESCRIPTION
Caused by `java.lang.IllegalArgumentException`
Wrong state class, expecting View State but received class `com.flamyoad.honnoki.utils.ui.ToggleView$ToggleSaveState instead.` This usually happens when two views of different type have the same id in the same hierarchy. This view's id is `id/btnFavouriteExpanded`. Make sure other views do not use the same id

```
Device
Brand:F15
Model:F15
Orientation: Portrait
RAM free: 160.44 MB
Disk free: 57.54 MB
Operating System
Version:Android 5.1
Orientation: Portrait
Rooted:No
```
^ Fix this crash that only happens on Lolipop device.