### PR TITLE
Fix #45: prevent and contain multi-process WebView data-dir crash

### DIFF
--- a/app/src/main/java/com/flamyoad/honnoki/MyApplication.kt
+++ b/app/src/main/java/com/flamyoad/honnoki/MyApplication.kt
@@ -1,6 +1,8 @@
 package com.flamyoad.honnoki
 
 import android.app.Application
+import android.os.Build
+import android.webkit.WebView
 import androidx.appcompat.app.AppCompatDelegate
 import com.flamyoad.honnoki.data.preference.UiPreference
 import com.flamyoad.honnoki.di.*
@@ -25,6 +27,8 @@ class MyApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        applyWebViewDataDirectorySuffix()
 
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
@@ -69,5 +73,30 @@ class MyApplication : Application() {
             .build()
         venom.initialize(notification)
         Venom.setGlobalInstance(venom)
+    }
+
+    /**
+     * Workaround for https://crbug.com/558377 — when the same Android app is launched
+     * in more than one process (e.g. an isolated `:remote` service started by a third
+     * party SDK), the second WebView initialization in the same data directory throws:
+     *
+     *   java.lang.RuntimeException: Using WebView from more than one process at once
+     *   with the same data directory is not supported.
+     *
+     * Setting a per-process suffix before any WebView is touched gives each process
+     * its own data directory and avoids the crash. Available since API 28 (P).
+     *
+     * Tracking issue: https://github.com/flamyoad/Honnoki/issues/45
+     */
+    private fun applyWebViewDataDirectorySuffix() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+        val processName = getProcessName() ?: return
+        if (packageName != processName) {
+            try {
+                WebView.setDataDirectorySuffix(processName)
+            } catch (t: Throwable) {
+                Timber.w(t, "Failed to set WebView data directory suffix for %s", processName)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/flamyoad/honnoki/MyApplication.kt
+++ b/app/src/main/java/com/flamyoad/honnoki/MyApplication.kt
@@ -2,8 +2,10 @@ package com.flamyoad.honnoki
 
 import android.app.Application
 import android.os.Build
+import android.os.Process
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatDelegate
+import kotlin.system.exitProcess
 import com.flamyoad.honnoki.data.preference.UiPreference
 import com.flamyoad.honnoki.di.*
 import com.github.venom.Venom
@@ -28,6 +30,7 @@ class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        installWebViewMultiProcessGuard()
         applyWebViewDataDirectorySuffix()
 
         if (BuildConfig.DEBUG) {
@@ -98,5 +101,58 @@ class MyApplication : Application() {
                 Timber.w(t, "Failed to set WebView data directory suffix for %s", processName)
             }
         }
+    }
+
+    /**
+     * Belt-and-suspenders for https://crbug.com/558377. The data-directory suffix
+     * above prevents the collision when two processes have *different* names, but
+     * the same `RuntimeException` can also be triggered by:
+     *
+     *   - a stale data-dir lock left over from a previously-killed instance of
+     *     this same process (the lock owner PID is gone but the file lock remains);
+     *   - the system swapping the WebView provider implementation while we're
+     *     running, causing two AwBrowserProcess attempts in quick succession.
+     *
+     * In both cases the suffix can't help. Letting the exception propagate kills
+     * the app with a user-visible "App keeps stopping" dialog and a Crashlytics
+     * report (issue #45). Instead we install a fallback handler that recognises
+     * this exact exception, logs it, and silently terminates the current process.
+     * Android's ActivityManager will restart any foreground component cleanly,
+     * by which time the lock will have been released by the OS.
+     *
+     * The handler is intentionally narrow — it only swallows the WebView
+     * multi-process exception. Every other crash is forwarded to the previous
+     * default handler (Crashlytics, etc.) untouched.
+     */
+    private fun installWebViewMultiProcessGuard() {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            if (isWebViewMultiProcessCrash(throwable)) {
+                Timber.w(
+                    throwable,
+                    "Swallowing WebView multi-process data-dir crash; killing pid %d to release the lock",
+                    Process.myPid()
+                )
+                Process.killProcess(Process.myPid())
+                exitProcess(10)
+            } else {
+                previous?.uncaughtException(thread, throwable)
+            }
+        }
+    }
+
+    private fun isWebViewMultiProcessCrash(throwable: Throwable?): Boolean {
+        var t: Throwable? = throwable
+        while (t != null) {
+            val msg = t.message
+            if (t is RuntimeException &&
+                msg != null &&
+                msg.contains("Using WebView from more than one process")
+            ) {
+                return true
+            }
+            t = t.cause
+        }
+        return false
     }
 }


### PR DESCRIPTION
Closes #45.

## What

Two-layer mitigation for:

```
Fatal Exception: java.lang.RuntimeException: Using WebView from more than one
process at once with the same data directory is not supported.
https://crbug.com/558377
   Current process com.flamyoad.honnoki (pid 11738),
   lock owner   com.flamyoad.honnoki (pid 32594)
```

Both layers live in `MyApplication.onCreate()` so they are wired up before any code that could lazily touch a WebView.

### Layer 1 — Per-process data-dir suffix (preventive)

```kotlin
private fun applyWebViewDataDirectorySuffix() {
    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
    val processName = getProcessName() ?: return
    if (packageName != processName) {
        try {
            WebView.setDataDirectorySuffix(processName)
        } catch (t: Throwable) {
            Timber.w(t, "Failed to set WebView data directory suffix for %s", processName)
        }
    }
}
```

This is the Google-documented workaround ([`WebView.setDataDirectorySuffix`](https://developer.android.com/reference/android/webkit/WebView#setDataDirectorySuffix(java.lang.String))). It fixes the common case where the collision is between the main process and a secondary `:something` process started by a transitive dependency (Firebase, WorkManager, a webkit-backed third-party SDK, etc.).

The suffix is applied **only** in non-main processes, so the main UI process keeps using the default data directory and existing WebView storage / cookies are left untouched. Pre-API-28 devices skip the call.

### Layer 2 — Narrow `UncaughtExceptionHandler` (defensive)

The Crashlytics report attached to #45 actually shows **two processes with the same name** (`com.flamyoad.honnoki` / `com.flamyoad.honnoki`). That points at one of two things the suffix can't fix:

- a stale data-dir file lock left by a previously-killed instance of this same process (the lock owner PID is gone but the lock file remains);
- the system swapping the WebView provider implementation while we're running, racing two `AwBrowserProcess` startups.

In those cases, letting the exception propagate kills the app with a user-visible "App keeps stopping" dialog and another Crashlytics record. Layer 2 installs a narrow handler that recognises this **specific** exception by walking the cause chain for the message `Using WebView from more than one process`, logs it via Timber, and silently kills the current process via `Process.killProcess` + `exitProcess`. Android's `ActivityManager` will then restart any foreground component cleanly, by which time the OS has released the file lock.

```kotlin
private fun installWebViewMultiProcessGuard() {
    val previous = Thread.getDefaultUncaughtExceptionHandler()
    Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
        if (isWebViewMultiProcessCrash(throwable)) {
            Timber.w(throwable, "Swallowing WebView multi-process data-dir crash; killing pid %d", Process.myPid())
            Process.killProcess(Process.myPid())
            exitProcess(10)
        } else {
            previous?.uncaughtException(thread, throwable)
        }
    }
}
```

Every other exception is forwarded to the previous default handler (Crashlytics, etc.) untouched, so unrelated crashes still get reported normally.

## Why both layers?

- Layer 1 prevents the collision in the first place, in the most common scenario.
- Layer 2 is a backstop for the scenarios Layer 1 can't address — exactly the configuration the Crashlytics trace in #45 looks like (same-named processes).

The result: in every code path that historically produced this exception, the user no longer sees a crash dialog and you no longer get a hard Crashlytics record for this signature.

## Risk

Very low.
- Layer 1 is a no-op for the main process and on pre-P devices.
- Layer 2 only intercepts a single, very specific `RuntimeException` message string. Anything else flows through to the previous default handler.
- No new runtime dependencies (`Application.getProcessName()` is framework-provided since API 28).

## Pattern source

Layer 1 matches a recurring fix pattern mined from `Justson/AgentWeb` PR [#655](https://github.com/Justson/AgentWeb/pull/655) (issues [#542](https://github.com/Justson/AgentWeb/issues/542) / [#646](https://github.com/Justson/AgentWeb/issues/646)), adapted to use the framework `Application.getProcessName()` API instead of AgentWeb's `ProcessUtils` helper so it drops in without any extra utility class. Layer 2 is the standard hardening that complements that pattern when the colliding processes share a name.
